### PR TITLE
feat: add tree API and UI

### DIFF
--- a/app/api/tree/route.js
+++ b/app/api/tree/route.js
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server.js";
+import { createServerClient } from "@supabase/ssr";
+
+function getClient() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY,
+    {
+      cookies: {
+        getAll: () => [],
+        setAll: () => {},
+      },
+    },
+  );
+}
+
+function buildTree(nodes) {
+  const map = new Map();
+  nodes.forEach((n) => {
+    map.set(n.id, { id: n.id, label: n.label, children: [], parent_id: n.parent_id });
+  });
+  const roots = [];
+  map.forEach((node) => {
+    if (node.parent_id) {
+      const parent = map.get(node.parent_id);
+      if (parent) {
+        parent.children.push(node);
+      }
+    } else {
+      roots.push(node);
+    }
+  });
+  const removeParent = (n) => {
+    const { id, label, children } = n;
+    return { id, label, children: children.map((c) => removeParent(c)) };
+  };
+  return roots.map((r) => removeParent(r));
+}
+
+export async function GET() {
+  const supabase = getClient();
+  const { data, error } = await supabase.from("tree_nodes").select();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  const tree = buildTree(data || []);
+  return NextResponse.json(tree);
+}
+
+export async function POST(req) {
+  const { label, parentId } = await req.json();
+  const supabase = getClient();
+  const { data, error } = await supabase
+    .from("tree_nodes")
+    .insert({ label, parent_id: parentId })
+    .select()
+    .single();
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return NextResponse.json(data);
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,10 +1,6 @@
-import { createClient } from "@/lib/supabase/server";
 import { RealtimeChat } from "@/components/realtime-chat";
 
-export default async function Page() {
-  const supabase = await createClient();
-  const { data: treeNodes } = await supabase.from("tree_nodes").select();
-
+export default function Page() {
   return (
     <>
       <RealtimeChat roomName="Chat" username="justinrunes" />

--- a/app/tree-nodes/page.tsx
+++ b/app/tree-nodes/page.tsx
@@ -1,8 +1,53 @@
-import { createClient } from "@/lib/supabase/server";
+"use client";
 
-export default async function Page() {
-  const supabase = await createClient();
-  const { data: treeNodes } = await supabase.from("tree_nodes").select();
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
-  return <pre>{JSON.stringify(treeNodes, null, 2)}</pre>;
+type TreeNode = { id: number; label: string; children: TreeNode[] };
+
+export default function Page() {
+  const [tree, setTree] = useState<TreeNode[]>([]);
+  const [parentId, setParentId] = useState("");
+  const [label, setLabel] = useState("");
+
+  const loadTree = async () => {
+    const res = await fetch("/api/tree");
+    const data = await res.json();
+    setTree(data);
+  };
+
+  const addNode = async () => {
+    await fetch("/api/tree", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        parentId: parentId ? Number(parentId) : null,
+        label,
+      }),
+    });
+    setParentId("");
+    setLabel("");
+    loadTree();
+  };
+
+  return (
+    <div className="space-y-4">
+      <Button onClick={loadTree}>Load Trees</Button>
+      <pre>{JSON.stringify(tree, null, 2)}</pre>
+      <div className="flex gap-2">
+        <Input
+          placeholder="parentId"
+          value={parentId}
+          onChange={(e) => setParentId(e.target.value)}
+        />
+        <Input
+          placeholder="label"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+        />
+        <Button onClick={addNode}>Add Node</Button>
+      </div>
+    </div>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.1",

--- a/tests/tree-api.test.js
+++ b/tests/tree-api.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { GET, POST } = await import('../app/api/tree/route.js');
+
+test('GET /api/tree returns array', async () => {
+  const res = await GET(new Request('http://localhost/api/tree'));
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(Array.isArray(data));
+});
+
+test('POST /api/tree inserts node', async () => {
+  const label = `test-node-${Date.now()}`;
+  const res = await POST(
+    new Request('http://localhost/api/tree', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ parentId: 1, label }),
+    }),
+  );
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.label, label);
+});


### PR DESCRIPTION
## Summary
- add REST API endpoints to fetch and insert tree nodes
- add interactive tree nodes page with load and add node buttons
- tidy chat page and add basic server tests

## Testing
- `npm run lint`
- `npm test` *(fails: Your project's URL and Key are required to create a Supabase client!)*

------
https://chatgpt.com/codex/tasks/task_b_689ccadd6bb0832e9a0f7d21f963e29f