### PR TITLE
Exclude tree-nodes page from auth protection

### DIFF
--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -41,7 +41,8 @@ export async function updateSession(request: NextRequest) {
   if (
     !user &&
     !request.nextUrl.pathname.startsWith('/login') &&
-    !request.nextUrl.pathname.startsWith('/auth')
+    !request.nextUrl.pathname.startsWith('/auth') &&
+    !request.nextUrl.pathname.startsWith('/tree-nodes')
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone()


### PR DESCRIPTION
## Summary
- Allow unauthenticated access to `/tree-nodes` page by skipping auth redirect

## Testing
- `npm test` *(fails: Cannot find module '/workspace/tree-api/app/api/tree/route.js')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689cd506b830832eb7cef7cf5bc1bf8f