### PR TITLE
feat(api): improve tree creation validation and responses

### DIFF
--- a/app/api/tree/route.ts
+++ b/app/api/tree/route.ts
@@ -16,6 +16,19 @@ type TreeNode = {
   children: TreeNode[];
 };
 
+function mapDbError(code?: string): number {
+  switch (code) {
+    case '23505':
+      return 409;
+    case '23503':
+    case '23502':
+    case 'PGRST116':
+      return 422;
+    default:
+      return 500;
+  }
+}
+
 async function getClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key =
@@ -106,16 +119,45 @@ export async function POST(req: Request) {
       label: string;
       parentId: Id | null;
     };
+
+    if (!label || !label.trim()) {
+      return NextResponse.json(
+        { error: 'Label is required' },
+        { status: 422 },
+      );
+    }
+
     const supabase = await getClient();
+
+    if (parentId !== null) {
+      const { data: parent, error: parentError } = await supabase
+        .from('tree_nodes')
+        .select('id')
+        .eq('id', parentId)
+        .single();
+      if (parentError || !parent) {
+        return NextResponse.json(
+          { error: 'Invalid parentId' },
+          { status: 422 },
+        );
+      }
+    }
+
     const { data, error } = await supabase
       .from('tree_nodes')
       .insert({ label, parent_id: parentId })
       .select()
       .single();
     if (error) {
-      return NextResponse.json({ error: error.message }, { status: 400 });
+      return NextResponse.json(
+        { error: error.message },
+        { status: mapDbError(error.code) },
+      );
     }
-    return NextResponse.json(data);
+    return NextResponse.json(data, {
+      status: 201,
+      headers: { Location: `/api/tree/${data.id}` },
+    });
   } catch (e) {
     if (e instanceof Error) {
       return NextResponse.json({ error: e.message }, { status: 500 });

--- a/tests/tree-api.test.ts
+++ b/tests/tree-api.test.ts
@@ -10,7 +10,25 @@ const nodes: { id: number; label: string; parent_id: number | null }[] = [
 jest.mock('@supabase/ssr', () => ({
   createServerClient: () => ({
     from: () => ({
-      select: () => Promise.resolve({ data: [...nodes], error: null }),
+      select: (columns?: string) => {
+        if (columns === '*') {
+          return Promise.resolve({ data: [...nodes], error: null });
+        }
+        return {
+          eq: (_col: string, id: number) => ({
+            single: () => {
+              const row = nodes.find((n) => n.id === id);
+              if (row) {
+                return Promise.resolve({ data: { id: row.id }, error: null });
+              }
+              return Promise.resolve({
+                data: null,
+                error: { code: 'PGRST116', message: 'No rows found' },
+              });
+            },
+          }),
+        };
+      },
       insert: ({
         label,
         parent_id,
@@ -20,6 +38,15 @@ jest.mock('@supabase/ssr', () => ({
       }) => ({
         select: () => ({
           single: () => {
+            if (nodes.some((n) => n.label === label)) {
+              return Promise.resolve({
+                data: null,
+                error: {
+                  code: '23505',
+                  message: 'duplicate key value violates unique constraint',
+                },
+              });
+            }
             const node = { id: nodes.length + 1, label, parent_id };
             nodes.push(node);
             return Promise.resolve({ data: node, error: null });
@@ -68,9 +95,52 @@ describe('tree API', () => {
         body: JSON.stringify({ parentId: 1, label }),
       }),
     );
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(201);
     const data = await res.json();
+    expect(res.headers.get('Location')).toBe(`/api/tree/${data.id}`);
     expect(data.label).toBe(label);
+  });
+
+  test('POST /api/tree rejects empty label', async () => {
+    const res = await POST(
+      new Request('http://localhost/api/tree', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parentId: 1, label: '' }),
+      }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  test('POST /api/tree rejects invalid parentId', async () => {
+    const label = `test-invalid-parent-${Date.now()}`;
+    const res = await POST(
+      new Request('http://localhost/api/tree', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parentId: 9999, label }),
+      }),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  test('POST /api/tree handles conflicts', async () => {
+    const label = 'duplicate';
+    await POST(
+      new Request('http://localhost/api/tree', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parentId: 1, label }),
+      }),
+    );
+    const res = await POST(
+      new Request('http://localhost/api/tree', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ parentId: 1, label }),
+      }),
+    );
+    expect(res.status).toBe(409);
   });
 
   test('DELETE /api/tree removes node', async () => {


### PR DESCRIPTION
## Summary
- validate labels and parent references before inserting tree nodes
- return 201 with a Location header for created nodes
- normalize database errors to conflict or validation responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ace6f14eb4832ea89545a31708b662